### PR TITLE
Add local pip package

### DIFF
--- a/GPXOverlay/frame.py
+++ b/GPXOverlay/frame.py
@@ -5,13 +5,14 @@ import jinja2
 import matplotlib.pyplot as plt
 import math
 import numpy as np
+import os
 
 # relative project paths to HTML and CSS templates
-SPEED_HTML = "./GPXOverlay/templates/speed_template.html"
-SPEED_CSS = './GPXOverlay/static/speed_template.css'
+SPEED_HTML_FILE_NAME = "./speed_template.html"
+SPEED_CSS_PATH = os.path.join(os.path.dirname(__file__), 'static/speed_template.css')
 
-ELEVATION_HTML = "./GPXOverlay/templates/elevation_template.html"
-ELEVATION_CSS = './GPXOverlay/static/elevation_template.css'
+ELEVATION_HTML_PATH = os.path.join(os.path.dirname(__file__), 'templates/elevation_template.html')
+ELEVATION_CSS_PATH = os.path.join(os.path.dirname(__file__), 'static/elevation_template.css')
 
 def generate_png(speed, time, id):
     """Generates a single frame as a png using the instantaneous speed and time
@@ -25,9 +26,12 @@ def generate_png(speed, time, id):
 
     """
     # Load template using jinja2
-    templateLoader = jinja2.FileSystemLoader(searchpath="./")
+    # jinja2 looks for files inside the specified template directory, so pass
+    # the file name rather than a path
+    templateLoader = jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), 'templates/'))
     templateEnv = jinja2.Environment(loader=templateLoader)
-    template = templateEnv.get_template(SPEED_HTML)
+    template = templateEnv.get_template(SPEED_HTML_FILE_NAME)
+
     # Modify template with instantaneous speed and time
     output_from_parsed_template = template.render(speed=speed,time=time)
 
@@ -37,7 +41,7 @@ def generate_png(speed, time, id):
 
     # Use imgkit to generate png from temporary HTML file
     options = {'quiet': '', 'transparent': '', 'width': 500, "crop-w":500, 'disable-smart-width': ''} # turn off intermediate status notifications
-    imgkit.from_file('temp/updated_speed.html', f'temp/speed{id}.png', options=options, css=SPEED_CSS) # output image to location w/ fstring
+    imgkit.from_file('temp/updated_speed.html', f'temp/speed{id}.png', options=options, css=SPEED_CSS_PATH) # output image to location w/ fstring
 
 
 def graph_elevation(time, elevation, size, avg, y_min, y_max):
@@ -99,4 +103,4 @@ def generate_elevation_frame(id):
     """
     # Use imgkit to generate png from HTML template
     options = {'quiet': '', 'transparent': '', 'width':775, 'height': 775, "crop-w":775, 'disable-smart-width': ''} # turn off intermediate status notifications
-    imgkit.from_file(ELEVATION_HTML, f'temp/elevation{id}.png', options=options) # output image to location w/ fstring
+    imgkit.from_file(ELEVATION_HTML_PATH, f'temp/elevation{id}.png', options=options) # output image to location w/ fstring

--- a/README.md
+++ b/README.md
@@ -13,6 +13,28 @@ video recorded by a drone.
 ![Speed Overlay](examples/test_speed.gif)
 
 
+## Installation
+### macOS
+1. Setup a virtual environment
+
+```bash
+python3 -m venv env
+source env/bin/activate
+```
+
+2. From the main directory, install `GPXOverlay` as an editable local pip package
+
+```bash
+pip3 install -e .
+```
+
+3. Install `wkhtmltopdf` and `ffmpeg` dependencies
+
+```bash
+brew cask install wkhtmltopdf
+brew install ffmpeg
+```
+
 ## Main Concept
 The GPS data stored in the GPX file contains many trackpoints containing
 elevation, longitude, and latitude.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This can be done in a few lines using the code from this library:
 
 ```python
 # load GPX file into an Analysis object
-data = analysis.Analysis('./examples/sample-data-short.gpx')
+data = analysis.Analysis('sample-data-short.gpx')
 # extract elevation, time, and velocity data as a numpy array of values
 elevations = data.elevation_data
 times = data.time_data
@@ -81,7 +81,7 @@ built into this library:
 
 ```python
 # load GPX file into an Overlay object and provide a path for output video
-elevation_overlay = overlay.Overlay('./examples/sample-data-short.gpx', './examples/video.mp4')
+elevation_overlay = overlay.Overlay('sample-data-short.gpx', 'video.mp4')
 elevation_overlay.generate_elevation_frames()
 elevation_overlay.convert_elevation_frames_to_video()
 elevation_overlay.overlay_elevation()
@@ -99,9 +99,10 @@ update this later.
 ## Running examples
 Run this command in the main directory
 ```shell
-python3 -m examples.overlay_speed.py
-python3 -m examples.overlay_elevation.py
-python3 -m examples.analyze_elevation.py
+cd examples
+python3 overlay_speed.py
+python3 overlay_elevation.py
+python3 analyze_elevation.py
 ```
 
 ## Project Overview & External Libraries Used

--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ brew cask install wkhtmltopdf
 brew install ffmpeg
 ```
 
+### Windows
+1. Setup a virtual environment
+
+```powershell
+python -m venv env
+.\env\Scripts\Activate.ps1
+```
+
+2. From the main directory, install `GPXOverlay` as an editable local pip package
+
+```powershell
+pip install -e .
+```
+
+3. Install `wkhtmltopdf` and `ffmpeg` dependencies
+
+```powershell
+choco install wkhtmltopdf
+choco install ffmpeg
+```
+
 ## Main Concept
 The GPS data stored in the GPX file contains many trackpoints containing
 elevation, longitude, and latitude.

--- a/examples/analyze_elevation.py
+++ b/examples/analyze_elevation.py
@@ -6,7 +6,7 @@ import imgkit
 
 def main():
     # load GPX file into an Analysis object and graph data
-    data = analysis.Analysis('./examples/sample-data-short.gpx')
+    data = analysis.Analysis('sample-data-short.gpx')
     ele = data.elevation_data
     fig, ax = plt.subplots()
     ax.plot(ele, color='#2d89ef')

--- a/examples/overlay_elevation.py
+++ b/examples/overlay_elevation.py
@@ -6,7 +6,7 @@ import imgkit
 
 def main():
     # load GPX file into an Overlay object and provide a path for output video
-    elevation_overlay = overlay.Overlay('./examples/sample-data-short.gpx', './examples/video.mp4')
+    elevation_overlay = overlay.Overlay('sample-data-short.gpx', 'video.mp4')
     elevation_overlay.generate_elevation_frames()
     elevation_overlay.convert_elevation_frames_to_video()
     elevation_overlay.overlay_elevation()

--- a/examples/overlay_speed.py
+++ b/examples/overlay_speed.py
@@ -2,7 +2,7 @@ from GPXOverlay import overlay
 
 def main():
     # load GPX file into an Overlay object and provide a path for output video
-    speed_overlay = overlay.Overlay('./examples/sample-data-short.gpx', './examples/video.mp4')
+    speed_overlay = overlay.Overlay('sample-data-short.gpx', 'video.mp4')
     speed_overlay.generate_overlay_frames()
     speed_overlay.convert_overlay_to_video()
     speed_overlay.overlay_video()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+jinja2
+matplotlib
+imgkit
+beautifulsoup4
+ffmpeg-python

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+def requirements():
+    list_requirements = []
+    with open('requirements.txt') as f:
+        for line in f:
+            list_requirements.append(line.rstrip())
+    return list_requirements
+
+setup(
+    name='GPXOverlay',
+    version='0.0.1',
+    packages=find_packages(),
+    description='overlay GPS data on videos using custom user-defined HTML',
+    install_requires=requirements(),
+)


### PR DESCRIPTION
To allow code using `GPXOverlay` to be run anywhere and to avoid using the less intuitive `python3 -m examples.overlay_speed.py`, the project will be made into a local editable pip package that can be installed.

# TODO
- [x] Add `setup.py` and `requirements.txt`
- [x] Update installation instructions
- [x] Update examples with correct paths
- [x] Make paths used within `GPXOverlay` relative to each source file 
    - So that the local pip package can work from anywhere
- [x] Maybe test on Windows 10?