### PR TITLE
Parallel overlay

### DIFF
--- a/GPXOverlay/overlay.py
+++ b/GPXOverlay/overlay.py
@@ -12,92 +12,28 @@ from GPXOverlay import frame
 from GPXOverlay import calculations
 from GPXOverlay import analysis
 
-class Overlay():
-    """Generates output video with overlayed data
 
-    Attributes:
-        gpx_data (str): Path to GPX file
-        video (str): Path to input video file
-    """
+def generate_overlay_frame(id, speed, time):
+    """Generates all overlay frames using velocity and time data"""
+    frame.generate_png(speed, time, id)
 
-    def __init__(self, gpx_data, input_video):
-        """ __init__ method for Analysis class
+def convert_overlay_to_video(frame_name_format, output_overlay_path, fps=30):
+    """Combines speed frames into a single video"""
+    (
+        ffmpeg
+        .input(frame_name_format, framerate=fps)
+        .output(output_overlay_path, vcodec='png')
+        .run()
+    )
 
-        Args:
-            gpx_file (str): Path to GPX file
-            video (str): Path to input video file
-        """
-        self.video = input_video
-        self.gpx_data = gpx_data
-
-        if not os.path.exists('temp'):
-            os.makedirs('temp')
-
-    def generate_overlay_frames(self):
-        """Generates all overlay frames using velocity and time data"""
-        data = analysis.Analysis(self.gpx_data)
-        times = data.time_data
-        velocities = data.velocity_data
-
-        for i, (velocity, time) in enumerate(zip(velocities, times)):
-            frame.generate_png(velocity, time, i)
-
-    def generate_elevation_frames(self):
-        """Generates all overlay frames using elevation and time data"""
-        data = analysis.Analysis(self.gpx_data)
-        ele = data.elevation_data
-
-        x = np.linspace(0,ele.size-1,ele.size)
-        avg = np.average(ele) * np.ones(ele.size)
-        y_min = np.amin(ele)
-        y_max = np.amax(ele)
-        y_min_array = y_max * np.ones(ele.size)
-        y_max_array = y_min * np.ones(ele.size)
-
-        for i in range(ele.size):
-            frame.graph_elevation(x[0:i],ele[0:i], ele.size, avg, y_min, y_max)
-            frame.generate_elevation_frame(i)
-
-
-    def convert_elevation_frames_to_video(self):
-        """Combines elevation frames into a single video"""
-        (
-            ffmpeg
-            .input('temp/elevation%d.png', framerate=30)
-            .output('temp/elevation_overlay.mp4', vcodec='png')
-            .run()
-        )
-
-    def overlay_elevation(self):
-        """Overlays video of elevation progression onto input video and
-        generates output video"""
-        input_video = ffmpeg.input(self.video)
-        overlay = ffmpeg.input('temp/elevation_overlay.mp4')
-        (
-            ffmpeg
-            .overlay(input_video, overlay, eof_action='repeat', x=25, y=25)
-            .output('test_elevation.mp4')
-            .run()
-        )
-
-
-    def convert_overlay_to_video(self):
-        """Combines speed frames into a single video"""
-        (
-            ffmpeg
-            .input('temp/speed%d.png', framerate=30)
-            .output('temp/speed_overlay.mp4', vcodec='png')
-            .run()
-        )
-
-    def overlay_video(self):
-        """Overlays video of speed progression onto input video and
-        generates output video"""
-        input_video = ffmpeg.input(self.video)
-        overlay = ffmpeg.input('temp/speed_overlay.mp4')
-        (
-            ffmpeg
-            .overlay(input_video, overlay, eof_action='repeat', x=25, y=25)
-            .output('test_speed.mp4')
-            .run()
-        )
+def overlay_video(input_video, overlay_video, output_video_path, overlay_x_pos, overlay_y_pos):
+    """Overlays video of speed progression onto input video and
+    generates output video"""
+    input_video = ffmpeg.input(input_video)
+    overlay = ffmpeg.input(overlay_video)
+    (
+        ffmpeg
+        .overlay(input_video, overlay, eof_action='repeat', x=overlay_x_pos, y=overlay_y_pos)
+        .output(output_video_path)
+        .run()
+    )

--- a/examples/overlay_speed.py
+++ b/examples/overlay_speed.py
@@ -1,10 +1,59 @@
-from GPXOverlay import overlay
+import os
+import multiprocessing
+import time
 
+from GPXOverlay import analysis
+from GPXOverlay.overlay import *
+from GPXOverlay import frame
+
+"""
 def main():
     # load GPX file into an Overlay object and provide a path for output video
     speed_overlay = overlay.Overlay('sample-data-short.gpx', 'video.mp4')
     speed_overlay.generate_overlay_frames()
     speed_overlay.convert_overlay_to_video()
     speed_overlay.overlay_video()
-
 main()
+"""
+
+if __name__ == '__main__':
+    gpx_file = 'sample-data-short.gpx'
+    data = analysis.Analysis(gpx_file)
+    time_points = data.time_data
+    velocities = data.velocity_data
+
+    if not os.path.exists('temp'):
+        os.makedirs('temp')
+
+    start = time.time()
+
+    # Create a pool with same number of worker processes as number of cpu cores
+    pool = multiprocessing.Pool()
+
+    for i, (velocity, time_point) in enumerate(zip(velocities, time_points)):
+        # Generate each overlay frame asynchronously
+        # Note: order is not guaranteed but that doesn't matter since we wait
+        # until all overlay frames are generated
+        pool.apply_async(generate_overlay_frame, [i, velocity, time_point])
+    pool.close()
+    pool.join()
+
+    end = time.time()
+
+    # Convert all individual overlay frames to a video
+    fps = 30
+    frame_name_format = 'temp/speed%d.png'
+    output_overlay_path = 'temp/speed_overlay.mp4'
+    convert_overlay_to_video(frame_name_format, output_overlay_path, fps)
+
+    # Overlay video onto input video
+    input_video = 'video.mp4'
+    overlay_video_path = 'temp/speed_overlay.mp4'
+    output_video_path = 'test_speed.mp4'
+    overlay_x_pos = 25
+    overlay_y_pos = 25
+
+    overlay_video(input_video, overlay_video_path, output_video_path, overlay_x_pos, overlay_y_pos)
+
+    print('total time (s) = ' + str(end-start))
+    print('fps = ' + str(len(time_points)/(end-start)))


### PR DESCRIPTION
Since the generation of png frames for the gps data overlay are independent from each other, the frames can be generated in separate asynchronous processes. 

The `GPXOverlay/overlay.py` file was also refactored into individual functions to make it easier to parallelize. Also, the `Overlay()` class seems to be unnecessary, so that's also why I'm splitting it into separate functions for now.

# TODO
- [x] Use `multiprocessing.Pool()` to speed up `for` loop generating overlay frames
- [x] Compare performance with previous code
    - On my 7 year old quad-core desktop cpu, the whole `overlay_speed.py` file runs over 3 times faster
    - Previous serial code: `708` seconds
    - New parallelized code: `213` seconds


 