### PR TITLE
Add interpolation to overlay_speed.py example

### DIFF
--- a/GPXOverlay/utils.py
+++ b/GPXOverlay/utils.py
@@ -1,0 +1,5 @@
+def round_fraction_to_nearest_int(frac_str):
+    num_str, denom_str = frac_str.split('/')
+    num = float(num_str)
+    denom = float(denom_str)
+    return round(num / denom)

--- a/examples/overlay_speed.py
+++ b/examples/overlay_speed.py
@@ -1,10 +1,14 @@
 import os
 import multiprocessing
 import time
+import ffmpeg
+import numpy as np
+from scipy.interpolate import interp1d
 
 from GPXOverlay import analysis
 from GPXOverlay.overlay import *
 from GPXOverlay import frame
+from GPXOverlay.utils import round_fraction_to_nearest_int
 
 """
 def main():
@@ -17,28 +21,54 @@ main()
 """
 
 if __name__ == '__main__':
-    gpx_file = 'sample-data-short.gpx'
+    start = time.time()
+    gpx_file = 'sample-data.gpx'
     data = analysis.Analysis(gpx_file)
     time_points = data.time_data
     velocities = data.velocity_data
+    input_video = 'video.mp4'
+
+    # Get video data required for interpolation
+    probe = ffmpeg.probe(input_video)
+    video_info = next(s for s in probe['streams'] if s['codec_type'] == 'video')
+    width = int(video_info['width'])
+    height = int(video_info['height'])
+    num_frames = int(video_info['nb_frames'])
+
+    # Perform interpolation since GPS sample rate and video frame rate are
+    # different. This generates intermediate GPS points to overlay on the video
+    # frames (assuming the usual 1Hz GPS sample rate and 30 fps video frame rate)
+
+    # Frame rate is given as a string containing a fraction
+    # TODO: check if rounding up to 30 fps from 29.97 fps is an issue
+    frame_rate = round_fraction_to_nearest_int(video_info['avg_frame_rate'])
+
+    # Currently the time data is not interpolated and is just repeated for all
+    # frames in the same second of video playback. This is just to avoid dealing
+    # with date and time formats
+    interpolated_time_points = np.repeat(time_points, frame_rate)
+    interpolated_time_points = interpolated_time_points[:num_frames]
+
+    # Create dummy points used for independent variables in interpolation
+    original_points = np.linspace(0, len(time_points) - 1, len(time_points))
+    interpolated_points = np.linspace(0, len(time_points) - 1, num_frames)
+
+    f_interpolate = interp1d(original_points, velocities, kind='cubic')
+    interpolated_velocities = f_interpolate(interpolated_points)
 
     if not os.path.exists('temp'):
         os.makedirs('temp')
 
-    start = time.time()
-
     # Create a pool with same number of worker processes as number of cpu cores
     pool = multiprocessing.Pool()
 
-    for i, (velocity, time_point) in enumerate(zip(velocities, time_points)):
+    for i, (velocity, time_point) in enumerate(zip(interpolated_velocities, interpolated_time_points)):
         # Generate each overlay frame asynchronously
         # Note: order is not guaranteed but that doesn't matter since we wait
         # until all overlay frames are generated
         pool.apply_async(generate_overlay_frame, [i, velocity, time_point])
     pool.close()
     pool.join()
-
-    end = time.time()
 
     # Convert all individual overlay frames to a video
     fps = 30
@@ -47,13 +77,14 @@ if __name__ == '__main__':
     convert_overlay_to_video(frame_name_format, output_overlay_path, fps)
 
     # Overlay video onto input video
-    input_video = 'video.mp4'
     overlay_video_path = 'temp/speed_overlay.mp4'
     output_video_path = 'test_speed.mp4'
     overlay_x_pos = 25
     overlay_y_pos = 25
 
     overlay_video(input_video, overlay_video_path, output_video_path, overlay_x_pos, overlay_y_pos)
+
+    end = time.time()
 
     print('total time (s) = ' + str(end-start))
     print('fps = ' + str(len(time_points)/(end-start)))

--- a/examples/sample-data.gpx
+++ b/examples/sample-data.gpx
@@ -1,0 +1,162 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Sean" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogr="http://osgeo.org/gdal" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata><bounds minlat="43.638486999999998" minlon="-79.383814999999998" maxlat="43.656914000000000" maxlon="-79.374593000000004"/></metadata>
+<trk>
+  <name>Sample Drone Data</name>
+  <type>9</type>
+  <trkseg>
+    <trkpt lat="43.65513" lon="-79.379793">
+      <ele>290.6666667</ele>
+      <time>2019-09-21T11:12:40Z</time>
+      <extensions>
+        <ogr:X>-79.379793</ogr:X>
+        <ogr:Y>43.65513</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.655085" lon="-79.379763">
+      <ele>291.3333333</ele>
+      <time>2019-09-21T11:12:41Z</time>
+      <extensions>
+        <ogr:X>-79.379763</ogr:X>
+        <ogr:Y>43.655085</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.655046" lon="-79.379729">
+      <ele>292.6666667</ele>
+      <time>2019-09-21T11:12:42Z</time>
+      <extensions>
+        <ogr:X>-79.379729</ogr:X>
+        <ogr:Y>43.655046</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.655008" lon="-79.379696">
+      <ele>292.6666667</ele>
+      <time>2019-09-21T11:12:43Z</time>
+      <extensions>
+        <ogr:X>-79.379696</ogr:X>
+        <ogr:Y>43.655008</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654971" lon="-79.379671">
+      <ele>293.3333333</ele>
+      <time>2019-09-21T11:12:44Z</time>
+      <extensions>
+        <ogr:X>-79.379671</ogr:X>
+        <ogr:Y>43.654971</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654932" lon="-79.379652">
+      <ele>293.3333333</ele>
+      <time>2019-09-21T11:12:45Z</time>
+      <extensions>
+        <ogr:X>-79.379652</ogr:X>
+        <ogr:Y>43.654932</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654891" lon="-79.379635">
+      <ele>297.3333333</ele>
+      <time>2019-09-21T11:12:46Z</time>
+      <extensions>
+        <ogr:X>-79.379635</ogr:X>
+        <ogr:Y>43.654891</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654846" lon="-79.37962">
+      <ele>295.3333333</ele>
+      <time>2019-09-21T11:12:47Z</time>
+      <extensions>
+        <ogr:X>-79.37962</ogr:X>
+        <ogr:Y>43.654846</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654777" lon="-79.3796">
+      <ele>295.3333333</ele>
+      <time>2019-09-21T11:12:48Z</time>
+      <extensions>
+        <ogr:X>-79.3796</ogr:X>
+        <ogr:Y>43.654777</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654696" lon="-79.379572">
+      <ele>295.3333333</ele>
+      <time>2019-09-21T11:12:49Z</time>
+      <extensions>
+        <ogr:X>-79.379572</ogr:X>
+        <ogr:Y>43.654696</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654606" lon="-79.379543">
+      <ele>296.6666667</ele>
+      <time>2019-09-21T11:12:50Z</time>
+      <extensions>
+        <ogr:X>-79.379543</ogr:X>
+        <ogr:Y>43.654606</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654526" lon="-79.379519">
+      <ele>296.6666667</ele>
+      <time>2019-09-21T11:12:51Z</time>
+      <extensions>
+        <ogr:X>-79.379519</ogr:X>
+        <ogr:Y>43.654526</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.65446" lon="-79.379496">
+      <ele>297.3333333</ele>
+      <time>2019-09-21T11:12:52Z</time>
+      <extensions>
+        <ogr:X>-79.379496</ogr:X>
+        <ogr:Y>43.65446</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654401" lon="-79.379473">
+      <ele>305.3333333</ele>
+      <time>2019-09-21T11:12:53Z</time>
+      <extensions>
+        <ogr:X>-79.379473</ogr:X>
+        <ogr:Y>43.654401</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654355" lon="-79.379447">
+      <ele>298.6666667</ele>
+      <time>2019-09-21T11:12:54Z</time>
+      <extensions>
+        <ogr:X>-79.379447</ogr:X>
+        <ogr:Y>43.654355</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654312" lon="-79.379421">
+      <ele>298.6666667</ele>
+      <time>2019-09-21T11:12:55Z</time>
+      <extensions>
+        <ogr:X>-79.379421</ogr:X>
+        <ogr:Y>43.654312</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654274" lon="-79.379404">
+      <ele>299.3333333</ele>
+      <time>2019-09-21T11:12:56Z</time>
+      <extensions>
+        <ogr:X>-79.379404</ogr:X>
+        <ogr:Y>43.654274</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654248" lon="-79.379387">
+      <ele>299.3333333</ele>
+      <time>2019-09-21T11:12:57Z</time>
+      <extensions>
+        <ogr:X>-79.379387</ogr:X>
+        <ogr:Y>43.654248</ogr:Y>
+      </extensions>
+    </trkpt>
+    <trkpt lat="43.654224" lon="-79.379378">
+      <ele>300.0</ele>
+      <time>2019-09-21T11:12:58Z</time>
+      <extensions>
+        <ogr:X>-79.379378</ogr:X>
+        <ogr:Y>43.654224</ogr:Y>
+      </extensions>
+    </trkpt>
+  </trkseg>
+</trk>
+</gpx>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 imgkit
 beautifulsoup4
 ffmpeg-python
+scipy


### PR DESCRIPTION
I modified the previous GPX data and uploaded it as a new GPX file was added so that the total time duration of the GPX data matched the duration of the input video.

Interpolation was achieved using scipy.interp1d. There's a few options for types of interpolation (ex. linear, cubic). I haven't really figured out what type of interpolation is commonly used, but I ended up choosing cubic interpolation because it's smoother and it takes very little extra time to run.
![gpx_interpolation_example](https://user-images.githubusercontent.com/35048935/92197699-8c74bd80-ee40-11ea-9e8b-bca2c86b4f49.png)

I will measure the actual total run time tomorrow, but it should be more or less comparable to the previous run times without interpolation. The "30 times" extra run time in https://github.com/Seangottarun/GPXOverlay/pull/4#issuecomment-683466252 is wrong because I forgot that the GPX data I had before was significantly longer than the actual input video. I think I purposefully used a GPX file that was 30x longer to simulate the actual run time when I later got interpolation working. 

Anyways, the long story short is that interpolation should work now and it shouldn't take a significantly longer time to run.

# TODO
- [x] Use `scipy.interp1d` for interpolating velocity data
- [x] Compare performance with and without interpolation
   - On my 7 year old quad-core desktop cpu, the whole `overlay_speed.py` file runs in about the same time with interpolation 
   - Previous code (with parallelization but no interpolation): `213` seconds
   - New code (with parallelization and interpolation): `155` seconds
- [x] Test with a different GPX and video file